### PR TITLE
Use Strict Comparison on Row and Column Numbers

### DIFF
--- a/src/LabelSheet.php
+++ b/src/LabelSheet.php
@@ -246,14 +246,14 @@ class LabelSheet
 
       // Get Row Placement
       $r = $item->GetRow();
-      if (!$r || $r > $this->template['rows']) {
+      if (null === $r || $r > $this->template['rows']) {
         $r = $current_row++;
       }
       $pdf->SetY($this->template['top'] + (($this->template['row_height'] + $this->template['row_gap']) * $r));
 
       // Get Column Placement
       $c = $item->GetCol();
-      if (!$c || $c > $this->template['columns']) {
+      if (null === $c || $c > $this->template['columns']) {
         $c = $current_col;
       }
       $pdf->SetX($this->template['left'] + (($this->template['column_width'] + $this->template['column_gap']) * $c));


### PR DESCRIPTION

With the following code, I'd expect all three labels to be on the same row. Row `0`.
```php
$labelSheet = new LabelSheet('Avery5160');

$labelSheet->addTextLabel(['Test'], 'C', 0, 0);
$labelSheet->addTextLabel(['Test'], 'C', 0, 1);
$labelSheet->addTextLabel(['Test'], 'C', 0, 2);

$pdf = new PDF();
$pdf->SetFont('Helvetica', '', 11);
  
$labelSheet->writeTo($pdf, true);

\file_put_contents('output.pdf', $pdf->Output('S', 'output.pdf'));
```

What I actually get:
![output](https://github.com/user-attachments/assets/67453e06-6f9e-4d51-ba9c-b9a26e61e81d)
