### PR TITLE
Fix PSR-4 Auto-Loading

### DIFF
--- a/src/LabelSheet.php
+++ b/src/LabelSheet.php
@@ -22,12 +22,10 @@
 
 namespace amattu2;
 
-use TypeError;
+use amattu2\LabelType\ImageLabel;
+use amattu2\LabelType\TextLabel;
 use InvalidArgumentException;
-
-require "LabelInterface.php";
-require "LabelType/TextLabel.php";
-require "LabelType/ImageLabel.php";
+use TypeError;
 
 /**
  * Avery Label FPDF Generator

--- a/src/LabelType/ImageLabel.php
+++ b/src/LabelType/ImageLabel.php
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace amattu2;
+namespace amattu2\LabelType;
+
+use amattu2\LabelInterface;
 
 /**
  * A Image Label for the LabelSheet

--- a/src/LabelType/TextLabel.php
+++ b/src/LabelType/TextLabel.php
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace amattu2;
+namespace amattu2\LabelType;
+
+use amattu2\LabelInterface;
 
 /**
  * A Basic Text Label


### PR DESCRIPTION
The `require` statements in [LabelSheet](https://github.com/amattu2/avery-fpdf-labels/blob/24ecab4c610227ed70901c77fff6059d1c9bbb86/src/LabelSheet.php#L28-L30) prevent the `LabelInterface` (and the `LableType`s) being loaded by Composer. When Composer tries to auto-load the class, an exception is throw stating that `amattu2\LabelInterface` can't be registered because the name is in use.

This PR fixes the namespaces in the included label types and removes the `require` statements.